### PR TITLE
Fix relative path issue for Node weather script

### DIFF
--- a/aprs-metric-2.sh
+++ b/aprs-metric-2.sh
@@ -8,7 +8,9 @@
 : "${PASSWORD:?Variable PASSWORD no definida}"
 
 # Ejecuta script Node.js (se espera que imprima JSON)
-weather_json=$(node index.js)
+# Usa la ruta absoluta para que funcione sin importar el directorio actual
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+weather_json=$(node "$SCRIPT_DIR/getweather/index.js")
 
 # Verifica si la salida es JSON válido
 if ! echo "$weather_json" | jq . >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- use an absolute path to run `getweather/index.js` regardless of current working directory

## Testing
- `bash -n aprs-metric-2.sh`
- `bash aprs-metric-2.sh` *(fails: Cannot find package 'weathercloud-js/dist/index.js', bc not found, aprs-weather-submit not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893649b633c8323a00651c8a5255e5c